### PR TITLE
Fixed writeChart() error message

### DIFF
--- a/nbdemetra-utils/src/main/java/ec/util/chart/swing/Charts.java
+++ b/nbdemetra-utils/src/main/java/ec/util/chart/swing/Charts.java
@@ -423,6 +423,7 @@ public final class Charts {
         for (JFreeChartWriter writer : Lookup.getDefault().lookupAll(JFreeChartWriter.class)) {
             if (mediaType.equals(writer.getMediaType())) {
                 writer.writeChart(stream, chart, width, height);
+                return;
             }
         }
         throw new IOException("Media type '" + mediaType + "' not supported");


### PR DESCRIPTION
Fixed error message that was always displayed when writing a chart as image