### PR TITLE
Fixed icon reference to DemetraUiIcon

### DIFF
--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/SaBatchUI.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/SaBatchUI.java
@@ -241,7 +241,7 @@ public class SaBatchUI extends AbstractSaProcessingTopComponent implements Multi
         toolBarRepresentation.addSeparator();
 
         JPopupMenu specPopup = new JPopupMenu();
-        final JButton specButton = (JButton) toolBarRepresentation.add(DropDownButtonFactory.createDropDownButton(ImageUtilities.loadImageIcon("ec/nbdemetra/sa/blog_16x16.png", false), specPopup));
+        final JButton specButton = (JButton) toolBarRepresentation.add(DropDownButtonFactory.createDropDownButton(DemetraUiIcon.BLOG_16, specPopup));
         specPopup.add(new SpecSelectionComponent()).addPropertyChangeListener(new PropertyChangeListener() {
             @Override
             public void propertyChange(PropertyChangeEvent evt) {

--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/revisionanalysis/RevisionAnalysisTopComponent.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/revisionanalysis/RevisionAnalysisTopComponent.java
@@ -155,7 +155,7 @@ public class RevisionAnalysisTopComponent extends WorkspaceTopComponent<Revision
 
         toolBarRepresentation.addSeparator();
         JPopupMenu specPopup = new JPopupMenu();
-        final JButton specButton = (JButton) toolBarRepresentation.add(DropDownButtonFactory.createDropDownButton(ImageUtilities.loadImageIcon("ec/nbdemetra/sa/blog_16x16.png", false), specPopup));
+        final JButton specButton = (JButton) toolBarRepresentation.add(DropDownButtonFactory.createDropDownButton(DemetraUiIcon.BLOG_16, specPopup));
         specButton.setFocusPainted(false);
         specPopup.add(new ec.nbdemetra.ws.ui.SpecSelectionComponent()).addPropertyChangeListener(new PropertyChangeListener() {
             @Override

--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/DemetraStatsPanel.form
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/DemetraStatsPanel.form
@@ -167,7 +167,7 @@
             </Property>
           </Properties>
           <AuxValues>
-            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="DropDownButtonFactory.createDropDownButton(ImageUtilities.loadImageIcon(&quot;ec/nbdemetra/sa/blog_16x16.png&quot;, false), specPopup)"/>
+            <AuxValue name="JavaCodeGenerator_CreateCodeCustom" type="java.lang.String" value="DropDownButtonFactory.createDropDownButton(DemetraUiIcon.BLOG_16, specPopup)"/>
           </AuxValues>
         </Component>
         <Component class="javax.swing.JLabel" name="selectedSpecLabel">

--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/DemetraStatsPanel.java
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/DemetraStatsPanel.java
@@ -122,7 +122,7 @@ final class DemetraStatsPanel extends javax.swing.JPanel {
         stabilityLength = new javax.swing.JSpinner();
         saPanel = new javax.swing.JPanel();
         defaultSpecLabel = new javax.swing.JLabel();
-        specButton = DropDownButtonFactory.createDropDownButton(ImageUtilities.loadImageIcon("ec/nbdemetra/sa/blog_16x16.png", false), specPopup);
+        specButton = DropDownButtonFactory.createDropDownButton(DemetraUiIcon.BLOG_16, specPopup);
         selectedSpecLabel = new javax.swing.JLabel();
         revisionHistoryPanel = new javax.swing.JPanel();
         estimationLabel = new javax.swing.JLabel();
@@ -134,13 +134,13 @@ final class DemetraStatsPanel extends javax.swing.JPanel {
 
         lastYearsPanel.setBorder(javax.swing.BorderFactory.createTitledBorder(org.openide.util.NbBundle.getMessage(DemetraStatsPanel.class, "DemetraStatsPanel.lastYearsPanel.border.title"))); // NOI18N
 
-        spectralLastYears.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(0), Integer.valueOf(0), null, Integer.valueOf(1)));
+        spectralLastYears.setModel(new javax.swing.SpinnerNumberModel(0, 0, null, 1));
 
         org.openide.awt.Mnemonics.setLocalizedText(spectralLabel, org.openide.util.NbBundle.getMessage(DemetraStatsPanel.class, "DemetraStatsPanel.spectralLabel.text")); // NOI18N
 
         org.openide.awt.Mnemonics.setLocalizedText(stabilityLabel, org.openide.util.NbBundle.getMessage(DemetraStatsPanel.class, "DemetraStatsPanel.stabilityLabel.text")); // NOI18N
 
-        stabilityLength.setModel(new javax.swing.SpinnerNumberModel(Integer.valueOf(8), Integer.valueOf(1), null, Integer.valueOf(1)));
+        stabilityLength.setModel(new javax.swing.SpinnerNumberModel(8, 1, null, 1));
 
         javax.swing.GroupLayout lastYearsPanelLayout = new javax.swing.GroupLayout(lastYearsPanel);
         lastYearsPanel.setLayout(lastYearsPanelLayout);


### PR DESCRIPTION
When using icons from standalone plugins (providing JDemetra+ installation path), if the path was relative to the image, it caused a ```NullPointerException``` because the image couldn't be found.
The path is then replaced by ```DemetraUiIcon.<<ICON_NAME>>```