### PR TITLE
Pre-specified outliers property sheet

### DIFF
--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/properties/l2fprod/CustomPropertyEditorRegistry.java
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/properties/l2fprod/CustomPropertyEditorRegistry.java
@@ -87,11 +87,12 @@ public enum CustomPropertyEditorRegistry {
         register(InterventionVariable[].class, new InterventionVariablesEditor());
         register(Sequence[].class, new SequencesEditor());
         register(OutlierDefinition[].class, new OutlierDefinitionsEditor());
-        register(OutlierType.class, new OutlierTypeSelector());
         register(String[].class, new StringCollectionEditor());
         register(Holidays.class, new HolidaysSelector());
         register(UserVariable.class, new UserVariableSelector());
         register(UserVariables.class, new UserVariablesEditor());
+        
+        registerEnumEditor(OutlierType.class, new OutlierTypeSelector());
     }
 
     public PropertyEditorRegistry getRegistry() {
@@ -110,6 +111,17 @@ public enum CustomPropertyEditorRegistry {
             editor.setAvailableValues(values);
             m_registry.registerEditor(type, editor);
         }
+    }
+
+    /**
+     * Used to register a custom enum editor. Then, the default
+     * EnumPropertyEditor is not used for the given property type.
+     *
+     * @param type Type of the property
+     * @param editor New editor for the property
+     */
+    public void registerEnumEditor(Class<? extends Enum<?>> type, PropertyEditor editor) {
+        m_registry.registerEditor(type, editor);
     }
 
     public void registerCompositeEditor(Class type) {


### PR DESCRIPTION
Property sheet now correctly uses a filtered editor of OutlierType's (AO, SO, TC, LS)

![prespecified-outliers](https://cloud.githubusercontent.com/assets/10207848/12450089/eef035e0-bf81-11e5-8054-7f89eeda4f77.png)
