### PR TITLE
Export specification to workspace

### DIFF
--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/ChangeSpecification.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/ChangeSpecification.java
@@ -1,6 +1,18 @@
 /*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
+ * Copyright 2016 National Bank of Belgium
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved 
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and 
+ * limitations under the Licence.
  */
 package ec.nbdemetra.sa.actions;
 
@@ -23,10 +35,10 @@ import org.openide.util.NbBundle.Messages;
         id = "ec.nbdemetra.sa.actions.ChangeSpecification")
 @ActionRegistration(displayName = "#CTL_ChangeSpecification", lazy = false)
 @ActionReferences({
-    @ActionReference(path = MultiProcessingManager.CONTEXTPATH, position = 1400),
-    @ActionReference(path = MultiProcessingManager.LOCALPATH, position = 1400)
+    @ActionReference(path = MultiProcessingManager.CONTEXTPATH + Specification.PATH, position = 1410),
+    @ActionReference(path = MultiProcessingManager.LOCALPATH + Specification.PATH, position = 1410)
 })
-@Messages("CTL_ChangeSpecification=Specification...")
+@Messages("CTL_ChangeSpecification=Select...")
 public final class ChangeSpecification extends AbstractViewAction<SaBatchUI> {
 
     public ChangeSpecification() {

--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/CopySpecToWorkSpace.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/CopySpecToWorkSpace.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 National Bank of Belgium
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved 
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and 
+ * limitations under the Licence.
+ */
+package ec.nbdemetra.sa.actions;
+
+import ec.nbdemetra.sa.MultiProcessingManager;
+import ec.nbdemetra.sa.SaBatchUI;
+import ec.nbdemetra.tramoseats.TramoSeatsDocumentManager;
+import ec.nbdemetra.tramoseats.TramoSeatsSpecificationManager;
+import ec.nbdemetra.ws.IWorkspaceItemManager;
+import ec.nbdemetra.ws.WorkspaceFactory;
+import ec.nbdemetra.ws.WorkspaceItem;
+import ec.nbdemetra.ws.actions.AbstractViewAction;
+import ec.nbdemetra.x13.X13DocumentManager;
+import ec.nbdemetra.x13.X13SpecificationManager;
+import ec.satoolkit.tramoseats.TramoSeatsSpecification;
+import ec.satoolkit.x13.X13Specification;
+import ec.tstoolkit.algorithm.IProcSpecification;
+import ec.tstoolkit.utilities.LinearId;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+
+/**
+ * Action used in the multi processing view to allow the export of the
+ * specification of the currently selected item to the workspace for further
+ * use.
+ *
+ * @author Mats Maggi
+ */
+@ActionID(category = "SaProcessing",
+        id = "ec.nbdemetra.sa.actions.CopySpecToWorkSpace")
+@ActionRegistration(displayName = "#CTL_CopySpecToWorkSpace", lazy = false)
+@ActionReferences({
+    @ActionReference(path = MultiProcessingManager.CONTEXTPATH + Specification.PATH, position = 1420),
+    @ActionReference(path = MultiProcessingManager.LOCALPATH + Specification.PATH, position = 1420)
+})
+@Messages("CTL_CopySpecToWorkSpace=Copy to workspace")
+public final class CopySpecToWorkSpace extends AbstractViewAction<SaBatchUI> {
+
+    public CopySpecToWorkSpace() {
+        super(SaBatchUI.class);
+        refreshAction();
+        putValue(NAME, Bundle.CTL_CopySpecToWorkSpace());
+    }
+
+    @Override
+    protected void refreshAction() {
+        SaBatchUI ui = context();
+        enabled = ui != null && ui.getSelectionCount() == 1;
+    }
+
+    @Override
+    protected void process(SaBatchUI cur) {
+        IProcSpecification spec = cur.getSelection()[0].getActiveSpecification();
+        LinearId id;
+        Class mgr;
+        if (spec instanceof TramoSeatsSpecification) {
+            id = TramoSeatsSpecificationManager.ID;
+            mgr = TramoSeatsDocumentManager.class;
+        } else if (spec instanceof X13Specification) {
+            id = X13SpecificationManager.ID;
+            mgr = X13DocumentManager.class;
+        } else {
+            return;
+        }
+
+        if (cur.getSelection()[0] != null) {
+            IWorkspaceItemManager wsMgr = WorkspaceFactory.getInstance().getManager(mgr);
+            WorkspaceItem<IProcSpecification> ndoc = WorkspaceItem.newItem(id, wsMgr.getNextItemName(null), spec);
+            WorkspaceFactory.getInstance().getActiveWorkspace().add(ndoc);
+        }
+    }
+}

--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/ExportSpecToWorkSpace.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/ExportSpecToWorkSpace.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 National Bank of Belgium
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved 
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and 
+ * limitations under the Licence.
+ */
+package ec.nbdemetra.sa.actions;
+
+import ec.nbdemetra.tramoseats.TramoSeatsSpecificationManager;
+import ec.nbdemetra.tramoseats.TramoSpecificationManager;
+import ec.nbdemetra.ws.IWorkspaceItemManager;
+import ec.nbdemetra.ws.WorkspaceFactory;
+import ec.nbdemetra.ws.WorkspaceItem;
+import ec.nbdemetra.ws.actions.AbstractViewAction;
+import ec.nbdemetra.ws.ui.WorkspaceTsTopComponent;
+import ec.nbdemetra.x13.RegArimaSpecificationManager;
+import ec.nbdemetra.x13.X13SpecificationManager;
+import ec.satoolkit.tramoseats.TramoSeatsSpecification;
+import ec.satoolkit.x13.X13Specification;
+import ec.tss.documents.TsDocument;
+import ec.tstoolkit.algorithm.IProcSpecification;
+import ec.tstoolkit.modelling.arima.tramo.TramoSpecification;
+import ec.tstoolkit.modelling.arima.x13.RegArimaSpecification;
+import ec.tstoolkit.utilities.Id;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+
+/**
+ * Action used in the SA views (for single time series) to allow the export of
+ * the specification used to the workspace for further use.
+ *
+ * @author Mats Maggi
+ */
+@ActionID(
+        category = "Tools",
+        id = "ec.nbdemetra.sa.actions.ExportSpecToWorkSpace")
+@ActionRegistration(
+        displayName = "#CTL_ExportSpecToWorkSpace", lazy = false)
+@ActionReferences({
+    @ActionReference(path = WorkspaceFactory.TSCONTEXTPATH, position = 1950)
+})
+@Messages("CTL_ExportSpecToWorkSpace=Copy spec. to workspace")
+public final class ExportSpecToWorkSpace extends AbstractViewAction<WorkspaceTsTopComponent> {
+
+    public ExportSpecToWorkSpace() {
+        super(WorkspaceTsTopComponent.class);
+        refreshAction();
+        putValue(NAME, Bundle.CTL_ExportSpecToWorkSpace());
+    }
+
+    @Override
+    protected void refreshAction() {
+        if (context() != null) {
+            WorkspaceItem<?> cur = context().getDocument();
+            enabled = cur.getElement() instanceof TsDocument;
+        } else {
+            enabled = false;
+        }
+    }
+
+    @Override
+    protected void process(WorkspaceTsTopComponent ws) {
+        WorkspaceItem<?> cur = ws.getDocument();
+        TsDocument doc = (TsDocument) cur.getElement();
+        IProcSpecification spec = doc.getSpecification();
+        Id id = getId(spec);
+        if (id != null) {
+            IWorkspaceItemManager wsMgr = WorkspaceFactory.getInstance().getManager(cur.getFamily());
+            WorkspaceItem<IProcSpecification> ndoc = WorkspaceItem.newItem(id, wsMgr.getNextItemName(null), spec);
+            WorkspaceFactory.getInstance().getActiveWorkspace().add(ndoc);
+        }
+    }
+
+    private Id getId(IProcSpecification spec) {
+        if (spec instanceof TramoSeatsSpecification) {
+            return TramoSeatsSpecificationManager.ID;
+        } else if (spec instanceof TramoSpecification) {
+            return TramoSpecificationManager.ID;
+        } else if (spec instanceof X13Specification) {
+            return X13SpecificationManager.ID;
+        } else if (spec instanceof RegArimaSpecification) {
+            return RegArimaSpecificationManager.ID;
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/RefreshDataAction.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/RefreshDataAction.java
@@ -12,8 +12,6 @@ import ec.nbdemetra.ws.nodes.ItemWsNode;
 import ec.nbdemetra.x13.RegArimaDocumentManager;
 import ec.nbdemetra.x13.X13DocumentManager;
 import ec.tss.documents.TsDocument;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import org.openide.DialogDisplayer;
 import org.openide.NotifyDescriptor;
 import org.openide.awt.ActionID;

--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/Specification.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/Specification.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016 National Bank of Belgium
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they will be approved 
+ * by the European Commission - subsequent versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ * 
+ * http://ec.europa.eu/idabc/eupl
+ * 
+ * Unless required by applicable law or agreed to in writing, software 
+ * distributed under the Licence is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and 
+ * limitations under the Licence.
+ */
+package ec.nbdemetra.sa.actions;
+
+import ec.nbdemetra.sa.MultiProcessingManager;
+import ec.nbdemetra.sa.SaBatchUI;
+import ec.nbdemetra.ui.Menus;
+import ec.nbdemetra.ws.actions.AbstractViewAction;
+import javax.swing.JMenu;
+import javax.swing.JMenuItem;
+import org.openide.awt.ActionID;
+import org.openide.awt.ActionReference;
+import org.openide.awt.ActionReferences;
+import org.openide.awt.ActionRegistration;
+import org.openide.util.NbBundle.Messages;
+import org.openide.util.actions.Presenter;
+
+/**
+ * Menu containing actions regarding specifications as sub-menu items.
+ *
+ * @author Mats Maggi
+ */
+@ActionID(category = "SaProcessing",
+        id = "ec.nbdemetra.sa.actions.Specification")
+@ActionRegistration(displayName = "#CTL_Specification", lazy = false)
+@ActionReferences({
+    @ActionReference(path = MultiProcessingManager.CONTEXTPATH, position = 1400),
+    @ActionReference(path = MultiProcessingManager.LOCALPATH, position = 1400)
+})
+@Messages("CTL_Specification=Specification")
+public class Specification extends AbstractViewAction<SaBatchUI> implements Presenter.Popup {
+
+    public static final String PATH = "/Specification";
+
+    public Specification() {
+        super(SaBatchUI.class);
+    }
+
+    @Override
+    public JMenuItem getPopupPresenter() {
+        refreshAction();
+        JMenu menu = new JMenu(Bundle.CTL_Specification());
+        menu.setEnabled(enabled);
+        Menus.fillMenu(menu, MultiProcessingManager.CONTEXTPATH + PATH);
+        return menu;
+    }
+
+    @Override
+    protected void refreshAction() {
+        SaBatchUI ui = context();
+        enabled = ui != null && ui.getSelectionCount() > 0;
+    }
+
+    @Override
+    protected void process(SaBatchUI cur) {
+    }
+
+}


### PR DESCRIPTION
Add the possibility to export a specification used on a SA document in the workspace for further usage.

Fixes #206 (Save specification)