### PR TITLE
Fix naming bug

### DIFF
--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/CopySpecToWorkSpace.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/CopySpecToWorkSpace.java
@@ -72,10 +72,10 @@ public final class CopySpecToWorkSpace extends AbstractViewAction<SaBatchUI> {
         Class mgr;
         if (spec instanceof TramoSeatsSpecification) {
             id = TramoSeatsSpecificationManager.ID;
-            mgr = TramoSeatsDocumentManager.class;
+            mgr = TramoSeatsSpecificationManager.class;
         } else if (spec instanceof X13Specification) {
             id = X13SpecificationManager.ID;
-            mgr = X13DocumentManager.class;
+            mgr = X13SpecificationManager.class;
         } else {
             return;
         }


### PR DESCRIPTION
Instead of the DocumentManager the SpecificationManager should be asked for the next name, else the Specifiations will be called Doc and the index will not be counted.