### PR TITLE
Copy specification to workspace

### DIFF
--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/CopySpecToWorkSpace.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/CopySpecToWorkSpace.java
@@ -67,7 +67,7 @@ public final class CopySpecToWorkSpace extends AbstractViewAction<SaBatchUI> {
 
     @Override
     protected void process(SaBatchUI cur) {
-        IProcSpecification spec = cur.getSelection()[0].getActiveSpecification();
+        IProcSpecification spec = cur.getSelection()[0].getEstimationSpecification();
         LinearId id;
         Class mgr;
         if (spec instanceof TramoSeatsSpecification) {


### PR DESCRIPTION
The action in the multiprocessing view now copies the estimation specification to the workspace.

Fixes #294