### PR TITLE
Bugfix: SaItem-Name

### DIFF
--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/ChangeSpecification.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/actions/ChangeSpecification.java
@@ -75,6 +75,7 @@ public final class ChangeSpecification extends AbstractViewAction<SaBatchUI> {
                 SaItem o = selection[i];
                 SaItem n = new SaItem(c.getSpecification(), o.getTs());
                 n.setMetaData(o.getMetaData());
+                n.setName(o.getRawName());
                 cur.getCurrentProcessing().replace(o, n);
             }
             cur.redrawAll();


### PR DESCRIPTION
SaItems lost their names when changing the specification with the "Select..."-Action in a Multidocument.