### PR TITLE
Changed behaviour of starred DataSource after editing it

### DIFF
--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/star/StarList.java
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/star/StarList.java
@@ -63,7 +63,7 @@ public final class StarList implements Iterable<DataSource> {
         return list.iterator();
     }
 
-    boolean isStarred(DataSource dataSource) {
+    public boolean isStarred(DataSource dataSource) {
         return list.contains(dataSource);
     }
 }

--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/tsproviders/DataSourceNode.java
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/tsproviders/DataSourceNode.java
@@ -264,7 +264,13 @@ public final class DataSourceNode extends AbstractNode {
             try {
                 if (DataSourceProviderBuddySupport.getDefault().get(loader).editBean("Edit data source", bean)) {
                     loader.close(dataSource);
-                    loader.open(loader.encodeBean(bean));
+                    DataSource editedDataSource = loader.encodeBean(bean);
+                    loader.open(editedDataSource);
+                    StarList starList = StarList.getInstance();
+                    if (starList.isStarred(dataSource)) {
+                        starList.toggle(dataSource);
+                        starList.toggle(editedDataSource);
+                    }
                 }
             } catch (IntrospectionException ex) {
                 Exceptions.printStackTrace(ex);

--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/tsproviders/DataSourceNode.java
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ui/tsproviders/DataSourceNode.java
@@ -24,6 +24,7 @@ import ec.nbdemetra.ui.IReloadable;
 import ec.nbdemetra.ui.nodes.FailSafeChildFactory;
 import ec.nbdemetra.ui.nodes.NodeAnnotator;
 import ec.nbdemetra.ui.nodes.Nodes;
+import ec.nbdemetra.ui.star.StarList;
 import static ec.nbdemetra.ui.tsproviders.DataSourceNode.ACTION_PATH;
 import ec.nbdemetra.ui.tssave.ITsSavable;
 import ec.tss.Ts;


### PR DESCRIPTION
* StarList allows access to isStarred for all 
With this change it is easier to check if any DataSource is starred/ a favourite and use this information.

* Suggestion to "Editing a starred DataSource"
With this change after editing a starred DataSource the changed DataSource will be starred and the old one loses the star. I think this is more intuitive than the old behaviour.