### PR TITLE
Change closing behaviour

### DIFF
--- a/nbdemetra-ui/src/main/java/ec/nbdemetra/ws/WorkspaceFactory.java
+++ b/nbdemetra-ui/src/main/java/ec/nbdemetra/ws/WorkspaceFactory.java
@@ -247,7 +247,7 @@ public class WorkspaceFactory implements LookupListener {
             Object notify = DialogDisplayer.getDefault().notify(nd);
             if (notify == NotifyDescriptor.YES_OPTION) {
                 ws_.save();
-            } else if (notify == NotifyDescriptor.CANCEL_OPTION) {
+            } else if (notify == NotifyDescriptor.CANCEL_OPTION || notify == NotifyDescriptor.CLOSED_OPTION) {
                 return false;
             }
         }


### PR DESCRIPTION
Changes closing behaviour of workspaces with unsaved changes:
If the user closes the message window without pressing any button (e.g. with the 'x' in the corner) JD+ doesn't close.