### PR TITLE
Show more information in SaItemNode

### DIFF
--- a/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/SaItemNode.java
+++ b/nbdemetra-sa/src/main/java/ec/nbdemetra/sa/SaItemNode.java
@@ -9,10 +9,17 @@ import ec.nbdemetra.ui.NbUtilities;
 import ec.nbdemetra.ui.nodes.ControlNode;
 import ec.nbdemetra.ui.properties.NodePropertySetBuilder;
 import ec.nbdemetra.ui.tsproviders.DataSourceProviderBuddySupport;
+import ec.tss.Ts;
+import ec.tss.TsStatus;
 import ec.tss.sa.SaItem;
 import ec.tss.tsproviders.utils.MultiLineNameUtil;
 import ec.tstoolkit.MetaData;
+import ec.tstoolkit.timeseries.simplets.TsData;
+import ec.tstoolkit.timeseries.simplets.TsFrequency;
+import ec.tstoolkit.timeseries.simplets.TsPeriod;
 import java.awt.Image;
+import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
 import org.openide.nodes.AbstractNode;
 import org.openide.nodes.Children;
@@ -53,6 +60,7 @@ public class SaItemNode extends AbstractNode {
         NodePropertySetBuilder b = new NodePropertySetBuilder();
         Sheet sheet = new Sheet();
         sheet.put(getDefinitionSheetSet(item, b));
+        sheet.put(getDataSheetSet(item, b));
 
         if (!MetaData.isNullOrEmpty(item.getMetaData())) {
             Sheet.Set info = NbUtilities.createMetadataPropertiesSet(item.getMetaData());
@@ -64,5 +72,44 @@ public class SaItemNode extends AbstractNode {
 
     private static Sheet.Set getDefinitionSheetSet(SaItem item, NodePropertySetBuilder b) {
         return ControlNode.getDefinitionSheetSet(item.getTs(), b);
+    }
+
+    private static Sheet.Set getDataSheetSet(SaItem item, NodePropertySetBuilder b) {
+        Ts ts = item.getTs();
+        b.reset("Input Data");
+        TsData data = ts.getTsData();
+        if (data != null) {
+            b.withEnum(TsFrequency.class).select(data, "getFrequency", null).display("Frequency").add();
+            b.with(TsPeriod.class).select(data, "getStart", null).display("First period").add();
+            b.with(TsPeriod.class).select(data, "getLastPeriod", null).display("Last period").add();
+            b.withInt().select(data, "getObsCount", null).display("Obs count").add();
+            b.with(TsData.class).selectConst("values", data).display("Values").add();
+        } else {
+            b.withEnum(TsStatus.class).select(ts, "hasData", null).display("Data status").add();
+            b.with(String.class).selectConst("InvalidDataCause", ts.getInvalidDataCause()).display("Invalid data cause").add();
+        }
+        MetaData md = ts.getMetaData();
+        if (md != null) {
+            md.entrySet().stream()
+                    .filter(o -> !isFreezeKey(o.getKey()))
+                    .sorted(Comparator.comparing(Map.Entry::getKey))
+                    .forEach(o -> b.with(String.class).selectConst(o.getKey(), o.getValue()).add());
+        } else {
+            b.withEnum(TsStatus.class).select(ts, "hasMetaData", null).display("Meta data status").add();
+        }
+        return b.build();
+    }
+
+    private static boolean isFreezeKey(String key) {
+        switch (key) {
+            case Ts.SOURCE_OLD:
+            case Ts.ID_OLD:
+            case MetaData.SOURCE:
+            case MetaData.ID:
+            case MetaData.DATE:
+                return true;
+            default:
+                return false;
+        }
     }
 }


### PR DESCRIPTION
Show the information of the input timeseries in the SaItemNode.
It would be helpful for our users to see more information without opening each input series first.